### PR TITLE
Works with .py files

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ const spec = openapi({
 | Option name          | Default |
 | -------------------- | ------- |
 | `cwd`                | The directory where `commentParser` was called |
-| `extension`          | `['.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx', '.yaml', '.yml']` |
+| `extension`          | `['.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx', '.yaml', '.yml', '.py']` |
 | `include`            | `['**']`|
 | `exclude`            | A large list that covers tests, coverage, and various development configs |
 | `excludeNodeModules` | `true` |

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,7 +13,7 @@ if (process.argv[2] === '--init') {
   fs.writeFileSync(
     '.openapirc.js',
     `module.exports = {
-  extension: ['.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx', '.yaml', '.yml'],
+  extension: ['.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx', '.yaml', '.yml', '.py'],
   include: ['**'],
   exclude: [
     'coverage/**',


### PR DESCRIPTION
Allows the comment parser to find comments in .py files. Temp fix as comments will still look like the following:

"""
    /**
    * GET /api/v1/hotels/info/{filter}
    * @tag Hotel
    * @summary Get filter list
    * @description Gets list of a type to filter Hotel data by.
    * @pathParam {FilterType} filter - The name of the filter to get options for.
    * @response 200 - OK
    * @response 400 - Filter Not Found Error
    * @response 500 - Internal Server Error
    */
"""