### PR TITLE
Feature/add support to request body example

### DIFF
--- a/src/util/commentsToOpenApi.test.ts
+++ b/src/util/commentsToOpenApi.test.ts
@@ -65,6 +65,7 @@ describe('commentsToOpenApi', () => {
 			 *
 			 * @bodyDescription an optional description
 			 * @bodyContent {string} application/json
+			 * @bodyExample {ExampleExample} application/json.ExampleExample
 			 * @bodyRequired
 			 *
 			 * @response                           200 - sup
@@ -164,6 +165,11 @@ describe('commentsToOpenApi', () => {
 							required: true,
 							content: {
 								'application/json': {
+									"examples": {
+										"ExampleExample": {
+											"$ref": "#/components/examples/ExampleExample"
+										}
+									},
 									schema: {
 										type: 'string',
 									},

--- a/src/util/commentsToOpenApi.ts
+++ b/src/util/commentsToOpenApi.ts
@@ -189,6 +189,23 @@ function tagsToObjects(tags: any[], verbose?: boolean) {
 					},
 				};
 
+			case 'bodyExample': {
+				const [contentType, example] = parsedResponse.name.split('.');
+				return {
+					requestBody: {
+						content: {
+							[contentType]: {
+								examples: {
+									[example]: {
+										$ref: `#/components/examples/${parsedResponse.rawType}`,
+									},
+								},
+							},
+						},
+					},
+				};
+			}
+
 			case 'bodyDescription':
 				return { requestBody: { description: nameAndDescription } };
 


### PR DESCRIPTION
first i want to thank you for this amazing package i always use in all of my projects.

So in the current project that i'm working i have the need to add body param examples and seeing the package it does not have support to it so i think that will be great add this capability to the package, i hope that you like of the PR and if have anything to question or contest, please let me know.