### PR TITLE
Fixes crashing issue when jsYaml.safeload throws an exception

### DIFF
--- a/src/util/parseFile.ts
+++ b/src/util/parseFile.ts
@@ -57,6 +57,20 @@ function parseFile(
 
 			return { parsedFile: [], messages: messages };
 		} catch (e) {
+			if(!e.mark) {
+				return {
+					parsedFile: [],
+					messages: [
+						{
+							severity: 1,
+							message: `cannot parse yaml ${file}, skipping file.`,
+							line: 0,
+							column: 0
+						},
+					],
+				};
+			}
+
 			return {
 				parsedFile: [],
 				messages: [


### PR DESCRIPTION
We had an issue using openapi-comment-parser when some Kubernetes yaml files were in our source folder.
Some of our yamls had '---' which allows us to combine multiple K8s objects in a single file.
After some digging we found the issue to be JSYaml that threw an exception and the parsefile function assumes that if you catch an exception there will be a mark object which isn't the case here.

The code simply checks for e.mark and if it doesn't exist it returns line and column 0 instead.